### PR TITLE
feat: select generated brush structures

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
@@ -1699,22 +1699,7 @@ public class EditSession implements Extent, AutoCloseable {
 
         return visitor.getAffected();
     }
-
-    /**
-     * Makes a cylinder.
-     *
-     * @param pos    Center of the cylinder
-     * @param block  The block pattern to use
-     * @param radius The cylinder's radius
-     * @param height The cylinder's up/down extent. If negative, extend downward.
-     * @param filled If false, only a shell will be generated.
-     * @return number of blocks changed
-     * @throws MaxChangedBlocksException thrown if too many blocks are changed
-     */
-    public int makeCylinder(BlockVector3 pos, Pattern block, double radius, int height, boolean filled) throws MaxChangedBlocksException {
-        return makeCylinder(pos, block, radius, radius, height, filled);
-    }
-
+    
     /**
      * Makes a cone.
      *

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/LocalSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/LocalSession.java
@@ -50,6 +50,7 @@ import com.sk89q.worldedit.session.Placement;
 import com.sk89q.worldedit.session.PlacementType;
 import com.sk89q.worldedit.session.request.Request;
 import com.sk89q.worldedit.util.Countable;
+import com.sk89q.worldedit.util.Location;
 import com.sk89q.worldedit.util.SideEffectSet;
 import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
 import com.sk89q.worldedit.world.World;
@@ -130,11 +131,15 @@ public class LocalSession {
     private Boolean navWandItemDefault;
 
 
-    public void toggleSelect(Actor actor) throws MaxChangedBlocksException {
+    public boolean selectStructure(Location clicked) {
         for (EditSession editSession : history) {
-            prepareEditingExtents(editSession, actor);
-            editSession.toggleSelect();
+            if (editSession.isGeneratedStructure(clicked)) {
+                editSession.toggleSelect();
+                return true;
+            }
         }
+
+        return false;
     }
 
     /**

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/LocalSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/LocalSession.java
@@ -119,6 +119,7 @@ public class LocalSession {
     private transient boolean hasBeenToldVersion;
     private transient boolean tracingActions;
 
+
     // Saved properties
     private String lastScript;
     private RegionSelectorType defaultSelector;
@@ -127,6 +128,14 @@ public class LocalSession {
     private Boolean wandItemDefault;
     private String navWandItem;
     private Boolean navWandItemDefault;
+
+
+    public void toggleSelect(Actor actor) throws MaxChangedBlocksException {
+        for (EditSession editSession : history) {
+            prepareEditingExtents(editSession, actor);
+            editSession.toggleSelect();
+        }
+    }
 
     /**
      * Construct the object.
@@ -248,7 +257,7 @@ public class LocalSession {
      * Performs an undo.
      *
      * @param newBlockBag a new block bag
-     * @param actor the actor
+     * @param actor       the actor
      * @return whether anything was undone
      */
     public EditSession undo(@Nullable BlockBag newBlockBag, Actor actor) {
@@ -257,9 +266,9 @@ public class LocalSession {
         if (historyPointer >= 0) {
             EditSession editSession = history.get(historyPointer);
             try (EditSession newEditSession =
-                     WorldEdit.getInstance().newEditSessionBuilder()
-                         .world(editSession.getWorld()).blockBag(newBlockBag).actor(actor)
-                         .build()) {
+                         WorldEdit.getInstance().newEditSessionBuilder()
+                                 .world(editSession.getWorld()).blockBag(newBlockBag).actor(actor)
+                                 .build()) {
                 prepareEditingExtents(newEditSession, actor);
                 editSession.undo(newEditSession);
             }
@@ -274,7 +283,7 @@ public class LocalSession {
      * Performs a redo.
      *
      * @param newBlockBag a new block bag
-     * @param actor the actor
+     * @param actor       the actor
      * @return whether anything was redone
      */
     public EditSession redo(@Nullable BlockBag newBlockBag, Actor actor) {
@@ -282,9 +291,9 @@ public class LocalSession {
         if (historyPointer < history.size()) {
             EditSession editSession = history.get(historyPointer);
             try (EditSession newEditSession =
-                     WorldEdit.getInstance().newEditSessionBuilder()
-                         .world(editSession.getWorld()).blockBag(newBlockBag).actor(actor)
-                         .build()) {
+                         WorldEdit.getInstance().newEditSessionBuilder()
+                                 .world(editSession.getWorld()).blockBag(newBlockBag).actor(actor)
+                                 .build()) {
                 prepareEditingExtents(newEditSession, actor);
                 editSession.redo(newEditSession);
             }
@@ -366,7 +375,7 @@ public class LocalSession {
     /**
      * Set the region selector.
      *
-     * @param world the world
+     * @param world    the world
      * @param selector the selector
      */
     public void setRegionSelector(World world, RegionSelector selector) {
@@ -422,7 +431,7 @@ public class LocalSession {
      */
     public Region getSelection(@Nullable World world) throws IncompleteRegionException {
         if (world == null || selector.getIncompleteRegion().getWorld() == null
-            || !selector.getIncompleteRegion().getWorld().equals(world)) {
+                || !selector.getIncompleteRegion().getWorld().equals(world)) {
             throw new IncompleteRegionException();
         }
         return selector.getRegion();
@@ -593,7 +602,6 @@ public class LocalSession {
      * Sets whether placement is at POS1 or PLAYER.
      *
      * @param placeAtPos1 true=POS1, false=PLAYER
-     *
      * @deprecated Use {@link #setPlacement(Placement)}
      */
     @Deprecated
@@ -605,7 +613,6 @@ public class LocalSession {
      * Gets whether placement is at POS1 or PLAYER.
      *
      * @return true=POS1, false=PLAYER
-     *
      * @deprecated Use {@link #getPlacement()}
      */
     @Deprecated
@@ -722,7 +729,7 @@ public class LocalSession {
      * @return the tool, or {@code null}
      * @throws InvalidToolBindException if the item can't be bound to that item
      * @deprecated Use {@link #getBrush(ItemType)} or {@link #forceBrush(ItemType, Brush, String)}
-     *     if you need to bind a specific brush
+     * if you need to bind a specific brush
      */
     @Deprecated
     public BrushTool getBrushTool(ItemType item) throws InvalidToolBindException {
@@ -750,8 +757,8 @@ public class LocalSession {
     /**
      * Force the tool to become a brush tool with the specified brush and permission.
      *
-     * @param item the item type
-     * @param brush the brush to bind
+     * @param item       the item type
+     * @param brush      the brush to bind
      * @param permission the permission to check before use is allowed
      * @return the brush tool assigned to the item type
      */
@@ -900,12 +907,12 @@ public class LocalSession {
         BaseBlock block = ServerCUIHandler.createStructureBlock(player);
         if (block != null) {
             LinCompoundTag tags = Objects.requireNonNull(
-                block.getNbt(), "createStructureBlock should return nbt"
+                    block.getNbt(), "createStructureBlock should return nbt"
             );
             BlockVector3 tempCuiTemporaryBlock = BlockVector3.at(
-                tags.getTag("x", LinTagType.intTag()).valueAsInt(),
-                tags.getTag("y", LinTagType.intTag()).valueAsInt(),
-                tags.getTag("z", LinTagType.intTag()).valueAsInt()
+                    tags.getTag("x", LinTagType.intTag()).valueAsInt(),
+                    tags.getTag("y", LinTagType.intTag()).valueAsInt(),
+                    tags.getTag("z", LinTagType.intTag()).valueAsInt()
             );
             // If it's null, we don't need to do anything. The old was already removed.
             if (cuiTemporaryBlock != null && !tempCuiTemporaryBlock.equals(cuiTemporaryBlock)) {
@@ -1113,10 +1120,10 @@ public class LocalSession {
 
         // Create an edit session
         EditSessionBuilder builder = WorldEdit.getInstance().newEditSessionBuilder()
-            .world(world)
-            .actor(actor)
-            .maxBlocks(getBlockChangeLimit())
-            .tracing(isTracingActions());
+                .world(world)
+                .actor(actor)
+                .maxBlocks(getBlockChangeLimit())
+                .tracing(isTracingActions());
         if (actor.isPlayer() && actor instanceof Player) {
             builder.blockBag(getBlockBag((Player) actor));
         }
@@ -1217,6 +1224,7 @@ public class LocalSession {
 
     /**
      * Get the preferred wand item for this user, or {@code null} to use the default.
+     *
      * @return item id of wand item, or {@code null}
      */
     public String getWandItem() {
@@ -1238,6 +1246,7 @@ public class LocalSession {
 
     /**
      * Get the preferred navigation wand item for this user, or {@code null} to use the default.
+     *
      * @return item id of nav wand item, or {@code null}
      */
     public String getNavWandItem() {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/LocalSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/LocalSession.java
@@ -133,8 +133,7 @@ public class LocalSession {
 
     public boolean selectStructure(Location clicked) {
         for (EditSession editSession : history) {
-            if (editSession.isGeneratedStructure(clicked)) {
-                editSession.toggleSelect();
+            if (editSession.selectStructure(clicked)) {
                 return true;
             }
         }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/GenerationCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/GenerationCommands.java
@@ -23,6 +23,10 @@ import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.LocalSession;
 import com.sk89q.worldedit.WorldEdit;
 import com.sk89q.worldedit.WorldEditException;
+import com.sk89q.worldedit.command.tool.brush.AbstractStructureBrush;
+import com.sk89q.worldedit.command.tool.brush.CylinderBrush;
+import com.sk89q.worldedit.command.tool.brush.HollowSphereBrush;
+import com.sk89q.worldedit.command.tool.brush.SphereBrush;
 import com.sk89q.worldedit.command.util.CommandPermissions;
 import com.sk89q.worldedit.command.util.CommandPermissionsConditionGenerator;
 import com.sk89q.worldedit.command.util.Logging;
@@ -73,38 +77,38 @@ public class GenerationCommands {
     }
 
     @Command(
-        name = "/hcyl",
-        desc = "Generates a hollow cylinder."
+            name = "/hcyl",
+            desc = "Generates a hollow cylinder."
     )
     @CommandPermissions("worldedit.generation.cylinder")
     @Logging(PLACEMENT)
     public int hcyl(Actor actor, LocalSession session, EditSession editSession,
                     @Arg(desc = "The pattern of blocks to generate")
-                        Pattern pattern,
+                    Pattern pattern,
                     @Arg(desc = "The radii of the cylinder. 1st is N/S, 2nd is E/W")
                     @Radii(2)
-                        List<Double> radii,
+                    List<Double> radii,
                     @Arg(desc = "The height of the cylinder", def = "1")
-                        int height) throws WorldEditException {
+                    int height) throws WorldEditException {
         return cyl(actor, session, editSession, pattern, radii, height, true);
     }
 
     @Command(
-        name = "/cyl",
-        desc = "Generates a cylinder."
+            name = "/cyl",
+            desc = "Generates a cylinder."
     )
     @CommandPermissions("worldedit.generation.cylinder")
     @Logging(PLACEMENT)
     public int cyl(Actor actor, LocalSession session, EditSession editSession,
                    @Arg(desc = "The pattern of blocks to generate")
-                       Pattern pattern,
+                   Pattern pattern,
                    @Arg(desc = "The radii of the cylinder. 1st is N/S, 2nd is E/W")
                    @Radii(2)
-                       List<Double> radii,
+                   List<Double> radii,
                    @Arg(desc = "The height of the cylinder", def = "1")
-                       int height,
+                   int height,
                    @Switch(name = 'h', desc = "Make a hollow cylinder")
-                       boolean hollow) throws WorldEditException {
+                   boolean hollow) throws WorldEditException {
         double radiusX;
         double radiusZ;
         switch (radii.size()) {
@@ -127,29 +131,29 @@ public class GenerationCommands {
         worldEdit.checkMaxRadius(height);
 
         BlockVector3 pos = session.getPlacementPosition(actor);
-        int affected = editSession.makeCylinder(pos, pattern, radiusX, radiusZ, height, !hollow);
+        int affected = new CylinderBrush(height).createStructure(editSession, pos, pattern, radiusX, radiusZ, height, !hollow);
         actor.printInfo(TranslatableComponent.of("worldedit.cyl.created", TextComponent.of(affected)));
         return affected;
     }
 
     @Command(
-        name = "/cone",
-        desc = "Generates a cone."
+            name = "/cone",
+            desc = "Generates a cone."
     )
     @CommandPermissions("worldedit.generation.cone")
     @Logging(PLACEMENT)
     public int cone(Actor actor, LocalSession session, EditSession editSession,
-                   @Arg(desc = "The pattern of blocks to generate")
-                       Pattern pattern,
-                   @Arg(desc = "The radii of the cone. 1st is N/S, 2nd is E/W")
-                   @Radii(2)
-                       List<Double> radii,
-                   @Arg(desc = "The height of the cone", def = "1")
-                       int height,
-                   @Switch(name = 'h', desc = "Make a hollow cone")
-                       boolean hollow,
-                   @Arg(desc = "Thickness of the hollow cone", def = "1")
-                       double thickness
+                    @Arg(desc = "The pattern of blocks to generate")
+                    Pattern pattern,
+                    @Arg(desc = "The radii of the cone. 1st is N/S, 2nd is E/W")
+                    @Radii(2)
+                    List<Double> radii,
+                    @Arg(desc = "The height of the cone", def = "1")
+                    int height,
+                    @Switch(name = 'h', desc = "Make a hollow cone")
+                    boolean hollow,
+                    @Arg(desc = "Thickness of the hollow cone", def = "1")
+                    double thickness
     ) throws WorldEditException {
         double radiusX;
         double radiusZ;
@@ -176,38 +180,38 @@ public class GenerationCommands {
     }
 
     @Command(
-        name = "/hsphere",
-        desc = "Generates a hollow sphere."
+            name = "/hsphere",
+            desc = "Generates a hollow sphere."
     )
     @CommandPermissions("worldedit.generation.sphere")
     @Logging(PLACEMENT)
     public int hsphere(Actor actor, LocalSession session, EditSession editSession,
                        @Arg(desc = "The pattern of blocks to generate")
-                           Pattern pattern,
+                       Pattern pattern,
                        @Arg(desc = "The radii of the sphere. Order is N/S, U/D, E/W")
                        @Radii(3)
-                           List<Double> radii,
+                       List<Double> radii,
                        @Switch(name = 'r', desc = "Raise the bottom of the sphere to the placement position")
-                           boolean raised) throws WorldEditException {
+                       boolean raised) throws WorldEditException {
         return sphere(actor, session, editSession, pattern, radii, raised, true);
     }
 
     @Command(
-        name = "/sphere",
-        desc = "Generates a filled sphere."
+            name = "/sphere",
+            desc = "Generates a filled sphere."
     )
     @CommandPermissions("worldedit.generation.sphere")
     @Logging(PLACEMENT)
     public int sphere(Actor actor, LocalSession session, EditSession editSession,
                       @Arg(desc = "The pattern of blocks to generate")
-                          Pattern pattern,
+                      Pattern pattern,
                       @Arg(desc = "The radii of the sphere. Order is N/S, U/D, E/W")
                       @Radii(3)
-                          List<Double> radii,
+                      List<Double> radii,
                       @Switch(name = 'r', desc = "Raise the bottom of the sphere to the placement position")
-                          boolean raised,
+                      boolean raised,
                       @Switch(name = 'h', desc = "Make a hollow sphere")
-                          boolean hollow) throws WorldEditException {
+                      boolean hollow) throws WorldEditException {
         double radiusX;
         double radiusY;
         double radiusZ;
@@ -236,7 +240,8 @@ public class GenerationCommands {
             pos = pos.add(0, (int) radiusY, 0);
         }
 
-        int affected = editSession.makeSphere(pos, pattern, radiusX, radiusY, radiusZ, !hollow);
+
+        int affected = new SphereBrush().createStructure(editSession, pos, pattern, radiusX, radiusY, radiusZ, !hollow);
         if (actor instanceof Player) {
             ((Player) actor).findFreePosition();
         }
@@ -245,18 +250,18 @@ public class GenerationCommands {
     }
 
     @Command(
-        name = "forestgen",
-        desc = "Generate a forest"
+            name = "forestgen",
+            desc = "Generate a forest"
     )
     @CommandPermissions("worldedit.generation.forest")
     @Logging(POSITION)
     public int forestGen(Actor actor, LocalSession session, EditSession editSession,
                          @Arg(desc = "The size of the forest, in blocks", def = "10")
-                             int size,
+                         int size,
                          @Arg(desc = "The type of forest", def = "tree")
-                             TreeType type,
+                         TreeType type,
                          @Arg(desc = "The density of the forest, between 0 and 100", def = "5")
-                             double density) throws WorldEditException {
+                         double density) throws WorldEditException {
         checkCommandArgument(0 <= density && density <= 100, "Density must be between 0 and 100");
         worldEdit.checkMaxRadius(size);
         density /= 100;
@@ -266,14 +271,14 @@ public class GenerationCommands {
     }
 
     @Command(
-        name = "pumpkins",
-        desc = "Generate pumpkin patches"
+            name = "pumpkins",
+            desc = "Generate pumpkin patches"
     )
     @CommandPermissions("worldedit.generation.pumpkins")
     @Logging(POSITION)
     public int pumpkins(Actor actor, LocalSession session, EditSession editSession,
                         @Arg(desc = "The size of the patch", def = "10")
-                            int size) throws WorldEditException {
+                        int size) throws WorldEditException {
         worldEdit.checkMaxRadius(size);
         int affected = editSession.makePumpkinPatches(session.getPlacementPosition(actor), size);
         actor.printInfo(TranslatableComponent.of("worldedit.pumpkins.created", TextComponent.of(affected)));
@@ -281,8 +286,8 @@ public class GenerationCommands {
     }
 
     @Command(
-        name = "/feature",
-        desc = "Generate Minecraft features"
+            name = "/feature",
+            desc = "Generate Minecraft features"
     )
     @CommandPermissions("worldedit.generation.feature")
     @Logging(POSITION)
@@ -298,14 +303,14 @@ public class GenerationCommands {
     }
 
     @Command(
-        name = "/structure",
-        desc = "Generate Minecraft structures"
+            name = "/structure",
+            desc = "Generate Minecraft structures"
     )
     @CommandPermissions("worldedit.generation.structure")
     @Logging(POSITION)
     public int structure(Actor actor, LocalSession session, EditSession editSession,
-                        @Arg(desc = "The structure")
-                        StructureType feature) throws WorldEditException {
+                         @Arg(desc = "The structure")
+                         StructureType feature) throws WorldEditException {
         if (editSession.getWorld().generateStructure(feature, editSession, session.getPlacementPosition(actor))) {
             actor.printInfo(TranslatableComponent.of("worldedit.structure.created"));
         } else {
@@ -315,32 +320,32 @@ public class GenerationCommands {
     }
 
     @Command(
-        name = "/hpyramid",
-        desc = "Generate a hollow pyramid"
+            name = "/hpyramid",
+            desc = "Generate a hollow pyramid"
     )
     @CommandPermissions("worldedit.generation.pyramid")
     @Logging(PLACEMENT)
     public int hollowPyramid(Actor actor, LocalSession session, EditSession editSession,
                              @Arg(desc = "The pattern of blocks to set")
-                                 Pattern pattern,
+                             Pattern pattern,
                              @Arg(desc = "The size of the pyramid")
-                                 int size) throws WorldEditException {
+                             int size) throws WorldEditException {
         return pyramid(actor, session, editSession, pattern, size, true);
     }
 
     @Command(
-        name = "/pyramid",
-        desc = "Generate a filled pyramid"
+            name = "/pyramid",
+            desc = "Generate a filled pyramid"
     )
     @CommandPermissions("worldedit.generation.pyramid")
     @Logging(PLACEMENT)
     public int pyramid(Actor actor, LocalSession session, EditSession editSession,
                        @Arg(desc = "The pattern of blocks to set")
-                           Pattern pattern,
+                       Pattern pattern,
                        @Arg(desc = "The size of the pyramid")
-                           int size,
+                       int size,
                        @Switch(name = 'h', desc = "Make a hollow pyramid")
-                           boolean hollow) throws WorldEditException {
+                       boolean hollow) throws WorldEditException {
         worldEdit.checkMaxRadius(size);
         BlockVector3 pos = session.getPlacementPosition(actor);
         int affected = editSession.makePyramid(pos, pattern, size, !hollow);
@@ -352,27 +357,27 @@ public class GenerationCommands {
     }
 
     @Command(
-        name = "/generate",
-        aliases = { "/gen", "/g" },
-        desc = "Generates a shape according to a formula.",
-        descFooter = "For details, see https://ehub.to/we/expr"
+            name = "/generate",
+            aliases = {"/gen", "/g"},
+            desc = "Generates a shape according to a formula.",
+            descFooter = "For details, see https://ehub.to/we/expr"
     )
     @CommandPermissions("worldedit.generation.shape")
     @Logging(ALL)
     public int generate(Actor actor, LocalSession session, EditSession editSession,
                         @Selection Region region,
                         @Arg(desc = "The pattern of blocks to set")
-                            Pattern pattern,
+                        Pattern pattern,
                         @Arg(desc = "Expression to test block placement locations and set block type", variable = true)
-                            List<String> expression,
+                        List<String> expression,
                         @Switch(name = 'h', desc = "Generate a hollow shape")
-                            boolean hollow,
+                        boolean hollow,
                         @Switch(name = 'r', desc = "Use the game's coordinate origin")
-                            boolean useRawCoords,
+                        boolean useRawCoords,
                         @Switch(name = 'o', desc = "Use the placement's coordinate origin")
-                            boolean offset,
+                        boolean offset,
                         @Switch(name = 'c', desc = "Use the selection's center as origin")
-                            boolean offsetCenter) throws WorldEditException {
+                        boolean offsetCenter) throws WorldEditException {
 
         final Vector3 zero;
         Vector3 unit;
@@ -421,27 +426,27 @@ public class GenerationCommands {
     }
 
     @Command(
-        name = "/generatebiome",
-        aliases = { "/genbiome", "/gb" },
-        desc = "Sets biome according to a formula.",
-        descFooter = "For details, see https://ehub.to/we/expr"
+            name = "/generatebiome",
+            aliases = {"/genbiome", "/gb"},
+            desc = "Sets biome according to a formula.",
+            descFooter = "For details, see https://ehub.to/we/expr"
     )
     @CommandPermissions("worldedit.generation.shape.biome")
     @Logging(ALL)
     public int generateBiome(Actor actor, LocalSession session, EditSession editSession,
                              @Selection Region region,
                              @Arg(desc = "The biome type to set")
-                                 BiomeType target,
+                             BiomeType target,
                              @Arg(desc = "Expression to test block placement locations and set biome type", variable = true)
-                                 List<String> expression,
+                             List<String> expression,
                              @Switch(name = 'h', desc = "Generate a hollow shape")
-                                 boolean hollow,
+                             boolean hollow,
                              @Switch(name = 'r', desc = "Use the game's coordinate origin")
-                                 boolean useRawCoords,
+                             boolean useRawCoords,
                              @Switch(name = 'o', desc = "Use the placement's coordinate origin")
-                                 boolean offset,
+                             boolean offset,
                              @Switch(name = 'c', desc = "Use the selection's center as origin")
-                                 boolean offsetCenter) throws WorldEditException {
+                             boolean offsetCenter) throws WorldEditException {
         final Vector3 zero;
         Vector3 unit;
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/HistoryCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/HistoryCommands.java
@@ -143,4 +143,12 @@ public class HistoryCommands {
         actor.printInfo(TranslatableComponent.of("worldedit.clearhistory.cleared"));
     }
 
+
+    @Command(
+            name = "rebrush",
+            aliases = { "/rebrush" },
+            desc = "Rebrushes the select region"
+    )
+    public void rebrush(Actor actor, LocalSession session) {
+    }
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/SelectionWand.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/SelectionWand.java
@@ -21,6 +21,7 @@ package com.sk89q.worldedit.command.tool;
 
 import com.sk89q.worldedit.LocalConfiguration;
 import com.sk89q.worldedit.LocalSession;
+import com.sk89q.worldedit.MaxChangedBlocksException;
 import com.sk89q.worldedit.entity.Player;
 import com.sk89q.worldedit.extension.platform.Actor;
 import com.sk89q.worldedit.extension.platform.Platform;
@@ -39,9 +40,10 @@ public class SelectionWand implements DoubleActionBlockTool {
         RegionSelector selector = session.getRegionSelector(player.getWorld());
         BlockVector3 blockPoint = clicked.toVector().toBlockPoint();
 
-        if (selector.selectPrimary(blockPoint, ActorSelectorLimits.forActor(player))) {
+        if (!session.selectStructure(clicked) && selector.selectPrimary(blockPoint, ActorSelectorLimits.forActor(player))) {
             selector.explainPrimarySelection(player, session, blockPoint);
         }
+
         return true;
     }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/brush/AbstractStructureBrush.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/brush/AbstractStructureBrush.java
@@ -1,0 +1,24 @@
+package com.sk89q.worldedit.command.tool.brush;
+
+import com.sk89q.worldedit.EditSession;
+import com.sk89q.worldedit.MaxChangedBlocksException;
+import com.sk89q.worldedit.function.pattern.Pattern;
+import com.sk89q.worldedit.math.BlockVector3;
+
+public abstract class AbstractStructureBrush implements Brush {
+    public void build(EditSession editSession, BlockVector3 position, Pattern pattern, double size) throws MaxChangedBlocksException {
+        this.createStructure(editSession, position, pattern, size);
+
+        editSession.storeGeneratedStructure();
+    }
+
+    abstract int createStructure(EditSession editSession, BlockVector3 position, Pattern pattern, double size) throws MaxChangedBlocksException;
+
+    protected static double lengthSq(double x, double y, double z) {
+        return (x * x) + (y * y) + (z * z);
+    }
+
+    protected static double lengthSq(double x, double z) {
+        return (x * x) + (z * z);
+    }
+}

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/brush/AbstractStructureBrush.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/brush/AbstractStructureBrush.java
@@ -6,7 +6,7 @@ import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.math.BlockVector3;
 
 public abstract class AbstractStructureBrush implements Brush {
-    public void build(EditSession editSession, BlockVector3 position, Pattern pattern, double size) throws MaxChangedBlocksException {
+    public final void build(EditSession editSession, BlockVector3 position, Pattern pattern, double size) throws MaxChangedBlocksException {
         this.createStructure(editSession, position, pattern, size);
 
         editSession.storeGeneratedStructure();

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/brush/CylinderBrush.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/brush/CylinderBrush.java
@@ -25,20 +25,107 @@ import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.world.block.BlockTypes;
 
-public class CylinderBrush implements Brush {
+public class CylinderBrush extends AbstractStructureBrush {
 
-    private final int height;
+    protected final int height;
 
     public CylinderBrush(int height) {
         this.height = height;
     }
 
     @Override
-    public void build(EditSession editSession, BlockVector3 position, Pattern pattern, double size) throws MaxChangedBlocksException {
+    public int createStructure(EditSession editSession, BlockVector3 position, Pattern pattern, double size) throws MaxChangedBlocksException {
         if (pattern == null) {
             pattern = BlockTypes.COBBLESTONE.getDefaultState();
         }
-        editSession.makeCylinder(position, pattern, size, size, height, true);
+        return createStructure(editSession, position, pattern, size, size, height, true);
+    }
+
+    /**
+     * Makes a cylinder.
+     *
+     * @param pos     Center of the cylinder
+     * @param block   The block pattern to use
+     * @param radiusX The cylinder's largest north/south extent
+     * @param radiusZ The cylinder's largest east/west extent
+     * @param height  The cylinder's up/down extent. If negative, extend downward.
+     * @param filled  If false, only a shell will be generated.
+     * @return number of blocks changed
+     * @throws MaxChangedBlocksException thrown if too many blocks are changed
+     */
+    public int createStructure(EditSession editSession, BlockVector3 pos, Pattern block, double radiusX, double radiusZ, int height, boolean filled) throws MaxChangedBlocksException {
+        int affected = 0;
+
+        radiusX += 0.5;
+        radiusZ += 0.5;
+
+        if (height == 0) {
+            return 0;
+        } else if (height < 0) {
+            height = -height;
+            pos = pos.subtract(0, height, 0);
+        }
+
+        if (pos.y() < editSession.getWorld().getMinY()) {
+            pos = pos.withY(editSession.getWorld().getMinY());
+        } else if (pos.y() + height - 1 > editSession.getWorld().getMaxY()) {
+            height = editSession.getWorld().getMaxY() - pos.y() + 1;
+        }
+
+        final double invRadiusX = 1 / radiusX;
+        final double invRadiusZ = 1 / radiusZ;
+
+        final int ceilRadiusX = (int) Math.ceil(radiusX);
+        final int ceilRadiusZ = (int) Math.ceil(radiusZ);
+
+        double nextXn = 0;
+        forX:
+        for (int x = 0; x <= ceilRadiusX; ++x) {
+            final double xn = nextXn;
+            nextXn = (x + 1) * invRadiusX;
+            double nextZn = 0;
+            forZ:
+            for (int z = 0; z <= ceilRadiusZ; ++z) {
+                final double zn = nextZn;
+                nextZn = (z + 1) * invRadiusZ;
+
+                double distanceSq = lengthSq(xn, zn);
+                if (distanceSq > 1) {
+                    if (z == 0) {
+                        break forX;
+                    }
+                    break forZ;
+                }
+
+                if (!filled) {
+                    if (lengthSq(nextXn, zn) <= 1 && lengthSq(xn, nextZn) <= 1) {
+                        continue;
+                    }
+                }
+
+                for (int y = 0; y < height; ++y) {
+                    if (editSession.setBlock(pos.add(x, y, z), block)) {
+                        ++affected;
+                    }
+                    if (editSession.setBlock(pos.add(-x, y, z), block)) {
+                        ++affected;
+                    }
+                    if (editSession.setBlock(pos.add(x, y, -z), block)) {
+                        ++affected;
+                    }
+                    if (editSession.setBlock(pos.add(-x, y, -z), block)) {
+                        ++affected;
+                    }
+                }
+            }
+        }
+
+        return affected;
+    }
+
+
+    public int createStructure(EditSession editSession, BlockVector3 pos, Pattern block, double size, boolean filled) throws MaxChangedBlocksException {
+        return createStructure(editSession, pos, block, size, size, height, filled);
     }
 
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/brush/HollowCylinderBrush.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/brush/HollowCylinderBrush.java
@@ -25,20 +25,13 @@ import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.world.block.BlockTypes;
 
-public class HollowCylinderBrush implements Brush {
-
-    private final int height;
-
+public class HollowCylinderBrush extends CylinderBrush {
     public HollowCylinderBrush(int height) {
-        this.height = height;
+        super(height);
     }
 
     @Override
-    public void build(EditSession editSession, BlockVector3 position, Pattern pattern, double size) throws MaxChangedBlocksException {
-        if (pattern == null) {
-            pattern = BlockTypes.COBBLESTONE.getDefaultState();
-        }
-        editSession.makeCylinder(position, pattern, size, size, height, false);
+    public int createStructure(EditSession editSession, BlockVector3 position, Pattern pattern, double size) throws MaxChangedBlocksException {
+        return createStructure(editSession, position, pattern, size, false);
     }
-
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/brush/HollowSphereBrush.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/brush/HollowSphereBrush.java
@@ -24,14 +24,14 @@ import com.sk89q.worldedit.MaxChangedBlocksException;
 import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.world.block.BlockTypes;
+import net.royawesome.jlibnoise.model.Sphere;
 
-public class HollowSphereBrush implements Brush {
-
+public class HollowSphereBrush extends SphereBrush {
     @Override
-    public void build(EditSession editSession, BlockVector3 position, Pattern pattern, double size) throws MaxChangedBlocksException {
+    public int createStructure(EditSession editSession, BlockVector3 position, Pattern pattern, double size) throws MaxChangedBlocksException {
         if (pattern == null) {
             pattern = BlockTypes.COBBLESTONE.getDefaultState();
         }
-        editSession.makeSphere(position, pattern, size, size, size, false);
+        return createStructure(editSession, position, pattern, size, size, size, false);
     }
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/brush/SelectableStructure.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/brush/SelectableStructure.java
@@ -1,0 +1,73 @@
+package com.sk89q.worldedit.command.tool.brush;
+
+import com.sk89q.worldedit.EditSession;
+import com.sk89q.worldedit.MaxChangedBlocksException;
+import com.sk89q.worldedit.function.pattern.Pattern;
+import com.sk89q.worldedit.history.change.BlockChange;
+import com.sk89q.worldedit.history.change.Change;
+import com.sk89q.worldedit.math.BlockVector3;
+import com.sk89q.worldedit.util.Location;
+import com.sk89q.worldedit.world.block.BlockTypes;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+public class SelectableStructure {
+    private boolean selected = false;
+    private final EditSession session;
+    private Pattern pattern;
+
+    List<BlockVector3> positions = new ArrayList<>();
+
+    public SelectableStructure(EditSession session) {
+        this.session = session;
+        this.pattern = BlockTypes.COBBLESTONE.getDefaultState();
+
+        for (Iterator<Change> it = session.getChangeSet().forwardIterator(); it.hasNext(); ) {
+            Change change = it.next();
+
+            if (change instanceof BlockChange blockChange) {
+                BlockVector3 position = blockChange.position();
+                positions.add(position);
+
+                pattern = blockChange.current();
+            }
+        }
+
+    }
+
+    private boolean locationIsInStructure(Location location) {
+        for (BlockVector3 position : positions) {
+            if (position.equals(location.toVector().toBlockPoint())) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public boolean select(Location clicked) {
+        if (!locationIsInStructure(clicked)) {
+            return false;
+        }
+
+        Pattern pattern = selected ? this.pattern : BlockTypes.LIGHT_BLUE_STAINED_GLASS.getDefaultState();
+
+        for (BlockVector3 position : positions) {
+            try {
+                session.setBlock(position, pattern);
+            } catch (MaxChangedBlocksException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        session.close();
+
+        selected = !selected;
+
+        return true;
+    }
+
+
+}

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/brush/SphereBrush.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/brush/SphereBrush.java
@@ -25,13 +25,106 @@ import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.world.block.BlockTypes;
 
-public class SphereBrush implements Brush {
+public class SphereBrush extends AbstractStructureBrush {
 
     @Override
-    public void build(EditSession editSession, BlockVector3 position, Pattern pattern, double size) throws MaxChangedBlocksException {
+    public int createStructure(EditSession editSession, BlockVector3 position, Pattern pattern, double size) throws MaxChangedBlocksException {
         if (pattern == null) {
             pattern = BlockTypes.COBBLESTONE.getDefaultState();
         }
-        editSession.makeSphere(position, pattern, size, size, size, true);
+
+        return createStructure(editSession, position, pattern, size, size, size, true);
+    }
+
+    /**
+     * Makes a sphere or ellipsoid.
+     *
+     * @param pos     Center of the sphere or ellipsoid
+     * @param block   The block pattern to use
+     * @param radiusX The sphere/ellipsoid's largest north/south extent
+     * @param radiusY The sphere/ellipsoid's largest up/down extent
+     * @param radiusZ The sphere/ellipsoid's largest east/west extent
+     * @param filled  If false, only a shell will be generated.
+     * @return number of blocks changed
+     * @throws MaxChangedBlocksException thrown if too many blocks are changed
+     */
+    public int createStructure(EditSession editSession, BlockVector3 pos, Pattern block, double radiusX, double radiusY, double radiusZ, boolean filled) throws MaxChangedBlocksException {
+        int affected = 0;
+
+        radiusX += 0.5;
+        radiusY += 0.5;
+        radiusZ += 0.5;
+
+        final double invRadiusX = 1 / radiusX;
+        final double invRadiusY = 1 / radiusY;
+        final double invRadiusZ = 1 / radiusZ;
+
+        final int ceilRadiusX = (int) Math.ceil(radiusX);
+        final int ceilRadiusY = (int) Math.ceil(radiusY);
+        final int ceilRadiusZ = (int) Math.ceil(radiusZ);
+
+        double nextXn = 0;
+        forX:
+        for (int x = 0; x <= ceilRadiusX; ++x) {
+            final double xn = nextXn;
+            nextXn = (x + 1) * invRadiusX;
+            double nextYn = 0;
+            forY:
+            for (int y = 0; y <= ceilRadiusY; ++y) {
+                final double yn = nextYn;
+                nextYn = (y + 1) * invRadiusY;
+                double nextZn = 0;
+                forZ:
+                for (int z = 0; z <= ceilRadiusZ; ++z) {
+                    final double zn = nextZn;
+                    nextZn = (z + 1) * invRadiusZ;
+
+                    double distanceSq = lengthSq(xn, yn, zn);
+                    if (distanceSq > 1) {
+                        if (z == 0) {
+                            if (y == 0) {
+                                break forX;
+                            }
+                            break forY;
+                        }
+                        break forZ;
+                    }
+
+                    if (!filled) {
+                        if (lengthSq(nextXn, yn, zn) <= 1 && lengthSq(xn, nextYn, zn) <= 1 && lengthSq(xn, yn, nextZn) <= 1) {
+                            continue;
+                        }
+                    }
+
+                    if (editSession.setBlock(pos.add(x, y, z), block)) {
+                        ++affected;
+                    }
+                    if (editSession.setBlock(pos.add(-x, y, z), block)) {
+                        ++affected;
+                    }
+                    if (editSession.setBlock(pos.add(x, -y, z), block)) {
+                        ++affected;
+                    }
+                    if (editSession.setBlock(pos.add(x, y, -z), block)) {
+                        ++affected;
+                    }
+                    if (editSession.setBlock(pos.add(-x, -y, z), block)) {
+                        ++affected;
+                    }
+                    if (editSession.setBlock(pos.add(x, -y, -z), block)) {
+                        ++affected;
+                    }
+                    if (editSession.setBlock(pos.add(-x, y, -z), block)) {
+                        ++affected;
+                    }
+                    if (editSession.setBlock(pos.add(-x, -y, -z), block)) {
+                        ++affected;
+                    }
+                }
+            }
+        }
+
+
+        return affected;
     }
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/PlatformManager.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/PlatformManager.java
@@ -21,6 +21,7 @@ package com.sk89q.worldedit.extension.platform;
 
 import com.sk89q.worldedit.LocalConfiguration;
 import com.sk89q.worldedit.LocalSession;
+import com.sk89q.worldedit.MaxChangedBlocksException;
 import com.sk89q.worldedit.WorldEdit;
 import com.sk89q.worldedit.command.tool.BlockTool;
 import com.sk89q.worldedit.command.tool.DoubleActionBlockTool;
@@ -107,8 +108,8 @@ public class PlatformManager {
         if (firstSeenVersion != null) {
             if (!firstSeenVersion.equals(platform.getVersion())) {
                 LOGGER.warn("Multiple ports of WorldEdit are installed but they report different versions ({} and {}). "
-                        + "If these two versions are truly different, then you may run into unexpected crashes and errors.",
-                    firstSeenVersion, platform.getVersion());
+                                + "If these two versions are truly different, then you may run into unexpected crashes and errors.",
+                        firstSeenVersion, platform.getVersion());
             }
         } else {
             firstSeenVersion = platform.getVersion();
@@ -168,8 +169,8 @@ public class PlatformManager {
             if (preferences.isEmpty()) {
                 // Not all platforms registered, this is being called too early!
                 throw new NoCapablePlatformException(
-                    "Not all platforms have been registered yet!"
-                        + " Please wait until WorldEdit is initialized."
+                        "Not all platforms have been registered yet!"
+                                + " Please wait until WorldEdit is initialized."
                 );
             }
             throw new NoCapablePlatformException("No platform was found supporting " + capability.name());
@@ -308,6 +309,7 @@ public class PlatformManager {
 
     /**
      * Get the initialized state of the Platform.
+     *
      * @return if the platform manager is initialized
      */
     public boolean isInitialized() {
@@ -364,6 +366,7 @@ public class PlatformManager {
         }
         LocalSession session = worldEdit.getSessionManager().get(actor);
 
+
         Request.reset();
         Request.request().setSession(session);
         Request.request().setWorld(player.getWorld());
@@ -388,6 +391,12 @@ public class PlatformManager {
                     if (((DoubleActionBlockTool) tool).actSecondary(queryCapability(Capability.WORLD_EDITING),
                             getConfiguration(), player, session, location, event.getFace())) {
                         event.setCancelled(true);
+
+                        try {
+                            session.toggleSelect(player);
+                        } catch (MaxChangedBlocksException e) {
+                            throw new RuntimeException(e);
+                        }
                     }
                 }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/PlatformManager.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/PlatformManager.java
@@ -391,12 +391,6 @@ public class PlatformManager {
                     if (((DoubleActionBlockTool) tool).actSecondary(queryCapability(Capability.WORLD_EDITING),
                             getConfiguration(), player, session, location, event.getFace())) {
                         event.setCancelled(true);
-
-                        try {
-                            session.toggleSelect(player);
-                        } catch (MaxChangedBlocksException e) {
-                            throw new RuntimeException(e);
-                        }
                     }
                 }
 


### PR DESCRIPTION
This feature allows users to select structures that were generated by brushes that place blocks in the world, e.g, Sphere, Cylinder, etc.